### PR TITLE
r2sflash: fix read only filesystem test

### DIFF
--- a/luci-app-r2sflasher/root/usr/bin/rom_flash
+++ b/luci-app-r2sflasher/root/usr/bin/rom_flash
@@ -173,6 +173,8 @@ if [ -f "$zstfile" ]; then
     echo u > /proc/sysrq-trigger || umount /
 
     rotestfile="/rotest.txt"
+    # here we rm it first
+    rm -f "$rotestfile"
     touch "$rotestfile"
     if [ $? -eq 0 ]; then
         rm "$rotestfile"


### PR DESCRIPTION
先尝试删除一下，
我的根目录下莫名其妙多了个rotest.txt
然后实际已经挂载成 readonly 了，但是判断错误